### PR TITLE
Fixed declaration for AuthorizationId. 

### DIFF
--- a/src/NetsSharp/Models/Summary.cs
+++ b/src/NetsSharp/Models/Summary.cs
@@ -6,7 +6,7 @@ namespace NetsSharp.Models
         public int AmountCredited { get; set; }
         public bool Annuled { get; set; }
         public bool Annulled { get; set; }
-        public int AuthorizationId { get; set; }
+        public string AuthorizationId { get; set; }
         public bool Authorized { get; set; }
     }
 }


### PR DESCRIPTION
Experienced exception in deserialization of Nets response in QueryAsync call because AuthorizationId was declared as int and not string.